### PR TITLE
Devotion duration should apply multiplicatively

### DIFF
--- a/src/Models/Dominion.php
+++ b/src/Models/Dominion.php
@@ -1431,13 +1431,14 @@ class Dominion extends AbstractModel
         }
 
         $multiplier = 1;
-        $multiplier += min($this->devotion->duration * 0.1 / 100, 1);
         $multiplier += $this->getBuildingPerkMultiplier('deity_power');
         $multiplier += $this->race->getPerkMultiplier('deity_power');
         $multiplier += $this->title->getPerkMultiplier('deity_power') * $this->getTitlePerkMultiplier();
         $multiplier += $this->getDecreePerkMultiplier('deity_power');
+        
+        $devotionDurationMultiplier = 1 + min($this->devotion->duration * 0.1 / 100, 1);
 
-        return (float)$this->deity->getPerkValue($perkKey) * $multiplier;
+        return (float)$this->deity->getPerkValue($perkKey) * $multiplier * $devotionDurationMultiplier;
     }
 
     /**


### PR DESCRIPTION
Devotion duration should apply multiplicatively with other mods, making it function as if it were the base values of the deity that increase over time.